### PR TITLE
Authenticated submissions

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -112,6 +112,7 @@ post '/submissions' do
 end
 
 post '/submissions/:id/moderate' do
+  redirect to('/auth/twitter') if current_user.nil?
   if params[:action] == 'accept'
     AcceptSubmissionJob.perform_async(params[:id]) if params[:action] == 'accept'
     flash[:notice] = 'Submission accepted'

--- a/app.rb
+++ b/app.rb
@@ -50,7 +50,6 @@ end
 get '/' do
   if current_user
     @sites = current_user.sites
-    @submissions = []
   end
   erb :index
 end

--- a/app.rb
+++ b/app.rb
@@ -107,6 +107,11 @@ post '/sites/:id/rebuild' do
   redirect to('/')
 end
 
+post '/submissions' do
+  submission = Submission.create(params[:submission])
+  redirect submission.site.url + '/submission-success'
+end
+
 post '/submissions/:id/moderate' do
   AcceptSubmissionJob.perform_async(params[:id]) if params[:action] == 'accept'
   'OK'

--- a/app.rb
+++ b/app.rb
@@ -112,6 +112,13 @@ post '/submissions' do
 end
 
 post '/submissions/:id/moderate' do
-  AcceptSubmissionJob.perform_async(params[:id]) if params[:action] == 'accept'
-  'OK'
+  if params[:action] == 'accept'
+    AcceptSubmissionJob.perform_async(params[:id]) if params[:action] == 'accept'
+    flash[:notice] = 'Submission accepted'
+  else
+    submission = Submission[params[:id]]
+    submission.delete
+    flash[:notice] = 'Submission rejected'
+  end
+  redirect to('/')
 end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -22,6 +22,11 @@ module SeePoliticiansTweet
       def csv_data
         @csv_data ||= open(csv_url).read
       end
+
+      def url
+        org, repo = github.split('/')
+        "https://#{org}.github.io/#{repo}"
+      end
     end
   end
 end

--- a/db/migrations/008_update_submissions_rename_country_id.rb
+++ b/db/migrations/008_update_submissions_rename_country_id.rb
@@ -1,0 +1,7 @@
+Sequel.migration do
+  change do
+    alter_table(:submissions) do
+      rename_column :country_id, :site_id
+    end
+  end
+end

--- a/jekyll/repo/_config.yml
+++ b/jekyll/repo/_config.yml
@@ -9,4 +9,4 @@ collections:
 # Site specific data
 site_id: 1
 list_owner_screen_name: political_wales
-submission_url: http://localhost:5000/applications/2/submissions
+submission_url: http://localhost:5000/submissions

--- a/jekyll/repo/_layouts/area.html
+++ b/jekyll/repo/_layouts/area.html
@@ -34,7 +34,7 @@ layout: default
             <h3>{{ politician.name }}</h3>
             <p>
                 <label for="id_username_{{ politician.id }}">Add this person’s Twitter username:</label>
-                <input id="id_username_{{ politician.id }}" class="form-control" type="text" name="submission[data][twitter]" placeholder="@username">
+                <input id="id_username_{{ politician.id }}" class="form-control" type="text" name="submission[twitter]" placeholder="@username">
                 <button type="submit" class="button">Save</button>
             </p>
         </form>

--- a/jekyll/repo/submission-success.html
+++ b/jekyll/repo/submission-success.html
@@ -1,0 +1,6 @@
+---
+layout: default
+---
+<div class="site-content site-content--empty">
+  <p>Your submission has been successful, thanks! It is now awaiting moderation by an admin.</p>
+</div>

--- a/views/index.erb
+++ b/views/index.erb
@@ -15,12 +15,6 @@
     </div>
   <% end %>
 
-  <% if @submissions.any? %>
-    <% @submissions.each do |submission| %>
-        <%= erb :submission, locals: { submission: submission } %>
-    <% end %>
-  <% end %>
-
 <% else %>
 
     <p class="login-prompt">

--- a/views/site.erb
+++ b/views/site.erb
@@ -16,14 +16,14 @@
     </h2>
   <% end %>
 
+  <form class="site__rebuild" action="<%= url "/sites/#{site.id}/rebuild" %>" method="post">
+      <button class="button button--secondary button--small" type="submit">Force rebuild</button>
+  </form>
+
   <% if site.submissions.any? %>
     <h3>Submissions</h3>
     <% site.submissions.each do |submission| %>
         <%= erb :submission, locals: { submission: submission } %>
     <% end %>
   <% end %>
-
-    <form class="site__rebuild" action="<%= url "/sites/#{site.id}/rebuild" %>" method="post">
-        <button class="button button--secondary button--small" type="submit">Force rebuild</button>
-    </form>
 </div>

--- a/views/site.erb
+++ b/views/site.erb
@@ -5,8 +5,8 @@
         <%= site.name %>
     </h2>
     <p class="site__url">
-        <a href="https://<%= settings.github_organization %>.github.io/<%= site.slug %>">
-            https://<%= settings.github_organization %>.github.io/<%= site.slug %>
+        <a href="<%= site.url %>">
+            <%= site.url %>
         </a>
     </p>
   <% else %>
@@ -14,10 +14,15 @@
     <h2 class="site__name">
         <%= site.name %>
     </h2>
-    <p class="site__url">
-        https://<%= settings.github_organization %>.github.io/<%= site.slug %>
-    </p>
   <% end %>
+
+  <% if site.submissions.any? %>
+    <h3>Submissions</h3>
+    <% site.submissions.each do |submission| %>
+        <%= erb :submission, locals: { submission: submission } %>
+    <% end %>
+  <% end %>
+
     <form class="site__rebuild" action="<%= url "/sites/#{site.id}/rebuild" %>" method="post">
         <button class="button button--secondary button--small" type="submit">Force rebuild</button>
     </form>

--- a/views/submission.erb
+++ b/views/submission.erb
@@ -1,17 +1,8 @@
-<div class="country">
-    <h2>New submission for <%= submission['country'] %></h2>
-    <ul>
-        <li>Person: <%= submission['person_id'] %></li>
-        <li>
-            <ul>
-                <% submission['updates'].each do |update| %>
-                    <li><b><%= update['field'] %></b>: <%= update['value'] %></li>
-                <% end %>
-            </ul>
-        </li>
-    </ul>
-    <form action="<%= url "/submissions/#{submission['id']}/moderate" %>" method="post">
-        <input type="submit" name="action" value="accept">
-        <input type="submit" name="action" value="reject">
-    </form>
-</div>
+<ul>
+    <li>Person: <%= submission.person_id %></li>
+    <li>Twitter: <%= submission.twitter %></li>
+</ul>
+<form action="<%= url "/submissions/#{submission['id']}/moderate" %>" method="post">
+    <input class="button button--primary" type="submit" name="action" value="accept">
+    <input class="button button--secondary" type="submit" name="action" value="reject">
+</form>

--- a/views/submission.erb
+++ b/views/submission.erb
@@ -2,7 +2,7 @@
     <li>Person: <%= submission.person_id %></li>
     <li>Twitter: <%= submission.twitter %></li>
 </ul>
-<form action="<%= url "/submissions/#{submission['id']}/moderate" %>" method="post">
+<form action="<%= url "/submissions/#{submission.id}/moderate" %>" method="post">
     <input class="button button--primary" type="submit" name="action" value="accept">
     <input class="button button--secondary" type="submit" name="action" value="reject">
 </form>


### PR DESCRIPTION
Instead of sending submission to the app-manager, then pulling the list of submission back to display to the user we simply store the submission in SeePoliticiansTweet until they've been accepted or rejected.

Fixes #7 
