### PR TITLE
Correctly display twitter handles in jekyll site

### DIFF
--- a/jekyll/repo/_layouts/area.html
+++ b/jekyll/repo/_layouts/area.html
@@ -19,7 +19,7 @@ layout: default
         {% if politician.screen_name %}
           <div class="person">
             <h3>{{ politician.name }}</h3>
-            <p><a href="#">@{{ politician.screen_name }}</a></p>
+            <p><a href="{{ politician.screen_name }}">@{{ politician.screen_name | replace: "@", "" | replace: "http://twitter.com/", "" | replace: "https://twitter.com/", "" }}</a></p>
           </div>
         {% endif %}
         {% endfor %}


### PR DESCRIPTION
Fixes #18.

Uses the `replace` Liquid filter to turn "username", "@username", and "http(s)://twitter.com/username" all into the standard "@username" display.

![screen shot 2015-09-03 at 11 01 42](https://cloud.githubusercontent.com/assets/739624/9655739/2e8ce76c-522b-11e5-8f28-db1ce22541d8.png)
