### PR TITLE
Improve smoothness of timeline loading, with loading message

### DIFF
--- a/jekyll/repo/_layouts/area.html
+++ b/jekyll/repo/_layouts/area.html
@@ -10,7 +10,8 @@ layout: default
           data-widget-id="598799140756320256"
           data-list-owner-screen-name="{{ site.list_owner_screen_name }}"
           data-list-slug="{{ page.list_slug }}">
-          Tweets from https://twitter.com/{{ site.list_owner_screen_name }}/lists/{{ page.list_slug }}
+          <span class="twitter-timeline__name">{{ page.name }}</span>
+          <span class="twitter-timeline__loading">Loading tweets…</span>
         </a>
     </div>
     <div class="site-content__people">

--- a/jekyll/repo/_sass/_typography.scss
+++ b/jekyll/repo/_sass/_typography.scss
@@ -102,3 +102,33 @@ input[type="search"] {
         border-color: darken($color-blue-700, 12%);
     }
 }
+
+
+// Replicate the styling from the Twitter widget
+// that will replace this element in a few seconds.
+a.twitter-timeline {
+  text-decoration: none;
+  color: inherit;
+  font: 12px/16px 'Helvetica Neue', Roboto, 'Segoe UI', Calibri, sans-serif;
+  padding: 12px;
+
+  &:hover, &:focus {
+    .twitter-timeline__loading {
+      text-decoration: underline;
+    }
+  }
+}
+
+.twitter-timeline__name {
+  display: block;
+  color: #292F33;
+  font-weight: bold;
+  font-size: 18px;
+  line-height: 18px;
+}
+
+.twitter-timeline__loading {
+  display: block;
+  color: #707070;
+  margin: 4px 0;
+}


### PR DESCRIPTION
Fixes #24 by making the transition between timelines smoother with styling that replicates the twitter timeline header.

Makes more sense when you see it in action:

![banner](https://cloud.githubusercontent.com/assets/739624/9656701/3679cdd0-5232-11e5-8295-869e2bc723c8.gif)
