### PR TITLE
Clean up styling of select boxes on admin page

### DIFF
--- a/views/new_site_form.erb
+++ b/views/new_site_form.erb
@@ -11,11 +11,14 @@
         </optgroup>
     </select>
 
+  <%# Disable grouping option for now %>
+  <% if false %>
     <label for="id_grouping">Group by:</label>
     <select name="grouping" id="id_grouping">
         <option value="area" selected>Area</option>
         <option value="group" disabled>Group</option>
     </select>
+  <% end %>
 
     <button class="button button--primary" type="submit">Create</button>
 </form>

--- a/views/sass/_components.scss
+++ b/views/sass/_components.scss
@@ -76,7 +76,8 @@
     select {
       display: inline-block;
       width: auto;
-      max-width: 11em;
+      max-width: 15em;
+      // max-width: 11em; // useful when there are two select boxes on a line
       margin: 0 1em 0 0.2em;
     }
 

--- a/views/sass/_components.scss
+++ b/views/sass/_components.scss
@@ -54,15 +54,33 @@
   }
 
   label {
+    display: block;
     font-size: 0.9em;
   }
 
   select {
-    margin: 0 1em 0 0.2em;
+    display: block;
+    width: 100%;
+    margin: 0.2em 0 1em 0;
   }
 
   .button {
-    @media (min-width: 40em) {
+    margin-top: 0.2em;
+  }
+
+  @media (min-width: 40em) {
+    label {
+      display: inline-block;
+    }
+
+    select {
+      display: inline-block;
+      width: auto;
+      max-width: 11em;
+      margin: 0 1em 0 0.2em;
+    }
+
+    .button {
       float: right;
       margin-top: -0.3em;
     }


### PR DESCRIPTION
Fixes #31.

Select boxes no longer extend outside the cards on mobile:

![screen shot 2015-09-03 at 12 05 33](https://cloud.githubusercontent.com/assets/739624/9656902/1c761748-5234-11e5-9016-bc4215be79d6.png)

And no longer wrap onto two lines on desktop:

![screen shot 2015-09-03 at 12 05 20](https://cloud.githubusercontent.com/assets/739624/9656907/1e9ef1ca-5234-11e5-9427-217aa5b6433f.png)
