### PR TITLE
Responsive layout

### DIFF
--- a/jekyll/repo/_layouts/area.html
+++ b/jekyll/repo/_layouts/area.html
@@ -15,7 +15,7 @@ layout: default
         </a>
     </div>
     <div class="site-content__people">
-        <h2>Politicians tweeting here:</h2>
+        <h2>Politicians tweeting here</h2>
         {% for politician in page.politicians %}
         {% if politician.screen_name %}
           <div class="person">

--- a/jekyll/repo/_layouts/area.html
+++ b/jekyll/repo/_layouts/area.html
@@ -25,7 +25,7 @@ layout: default
         {% endif %}
         {% endfor %}
 
-        <h2>Politicians not on Twitter</h2>
+        <h2>Other politicians here</h2>
 
         {% for politician in page.politicians %}
         {% unless politician.screen_name %}
@@ -34,9 +34,11 @@ layout: default
             <input type="hidden" name="submission[person_id]" value="{{ politician.id }}">
             <h3>{{ politician.name }}</h3>
             <p>
-                <label for="id_username_{{ politician.id }}">Add this person’s Twitter username:</label>
-                <input id="id_username_{{ politician.id }}" class="form-control" type="text" name="submission[twitter]" placeholder="@username">
-                <button type="submit" class="button">Save</button>
+                <label for="id_username_{{ politician.id }}">Add a Twitter username:</label>
+                <span class="input-append">
+                    <input id="id_username_{{ politician.id }}" class="form-control" type="text" name="submission[twitter]" placeholder="@username">
+                    <button type="submit" class="button">Add</button>
+                </span>
             </p>
         </form>
         {% endunless %}

--- a/jekyll/repo/_sass/_area-list.scss
+++ b/jekyll/repo/_sass/_area-list.scss
@@ -17,5 +17,21 @@
             background-color: $color-blue-500;
             color: #fff;
         }
+
+        &:last-child {
+          border-bottom: none;
+        }
     }
+}
+
+@media (max-width: $increment * 699) {
+  .area-list {
+    border-right: none;
+    background-color: mix(#fff, $color-bluegrey-50, 50%);
+    border-bottom: 1px solid $color-bluegrey-100;
+
+    a {
+      padding: 0.6em 1em;
+    }
+  }
 }

--- a/jekyll/repo/_sass/_layout.scss
+++ b/jekyll/repo/_sass/_layout.scss
@@ -66,6 +66,7 @@ html, body {
     right: 0;
     bottom: 0;
     width: $desktop-people-width;
+    overflow: auto;
 }
 
 .twitter-timeline {

--- a/jekyll/repo/_sass/_layout.scss
+++ b/jekyll/repo/_sass/_layout.scss
@@ -1,9 +1,20 @@
+$desktop-header-width: 15em;
+$desktop-nav-width: 18em;
+$desktop-timeline-width: 30em;
+$desktop-people-width: 15em;
+
+$tablet-nav-width: 15em;
+$tablet-people-width: 12em;
+
+$phablet-header-height: 3em;
+$phablet-nav-height: 6em;
+
 html, body {
     // Set a sizing context for children of body
     // eg: so they can stretch to full window height.
     width: 100%;
     height: 100%;
-    display: relative;
+    position: relative;
 }
 
 *, *:before, *:after {
@@ -15,7 +26,7 @@ html, body {
     top: 0;
     left: 0;
     bottom: 0;
-    width: 15em;
+    width: $desktop-header-width;
     overflow: auto;
 }
 
@@ -23,8 +34,8 @@ html, body {
     position: absolute;
     top: 0;
     bottom: 0;
-    left: 15em;
-    width: 18em;
+    left: $desktop-header-width;
+    width: $desktop-nav-width;
     overflow: auto;
 }
 
@@ -35,8 +46,9 @@ html, body {
     right: 0;
     bottom: 0;
     height: 100%;
-    left: 15em + 18em;
+    left: $desktop-header-width + $desktop-nav-width;
     overflow: auto;
+    max-width: $desktop-timeline-width + $desktop-people-width;
 }
 
 .site-content__tweets {
@@ -44,8 +56,8 @@ html, body {
     top: 0;
     left: 0;
     bottom: 0;
+    right: $desktop-people-width;
     height: 100%;
-    width: 30em;
 }
 
 .site-content__people {
@@ -53,10 +65,74 @@ html, body {
     top: 0;
     right: 0;
     bottom: 0;
-    left: 30em;
+    width: $desktop-people-width;
 }
 
 .twitter-timeline {
     height: 100% !important;
     display: block !important;
+}
+
+iframe.twitter-timeline[data-widget-id] + a.twitter-timeline {
+  // There's a split second where the iframe and the placeholder link
+  // both exist in the DOM at the same time, while the twitter widget is
+  // in the process of loading. This is the gap between the iframe being
+  // given a "data-widget-id" attribute, and the placeholder element
+  // being hidden. So, we hide the placeholder with CSS here, to avoid
+  // a scrollbar being shown (because of two 100% height elements).
+  display: none !important;
+}
+
+@media (max-width: $increment * 1023) {
+  .site-header {
+    width: $tablet-nav-width;
+    bottom: 50%;
+  }
+
+  .area-list {
+    left: 0;
+    top: 50%;
+    width: $tablet-nav-width;
+  }
+
+  .site-content {
+    left: $tablet-nav-width;
+  }
+
+  .site-content__tweets {
+    right: $tablet-people-width;
+  }
+
+  .site-content__people {
+    width: $tablet-people-width;
+  }
+}
+
+@media (max-width: $increment * 699) {
+  .site-header {
+    width: 100%;
+    height: $phablet-header-height;
+  }
+
+  .area-list {
+    width: 100%;
+    top: $phablet-header-height;
+    height: $phablet-nav-height;
+  }
+
+  .site-content {
+    top: $phablet-header-height + $phablet-nav-height;
+    left: 0;
+    height: auto;
+  }
+}
+
+@media (max-width: $increment * 499) {
+  .site-content__tweets {
+    right: 0;
+  }
+
+  .site-content__people {
+    display: none;
+  }
 }

--- a/jekyll/repo/_sass/_mixins.scss
+++ b/jekyll/repo/_sass/_mixins.scss
@@ -1,3 +1,15 @@
+@mixin clearfix {
+  &:before,
+  &:after {
+    content: " ";
+    display: table;
+  }
+
+  &:after {
+    clear: both;
+  }
+}
+
 @mixin box-sizing($boxmodel) {
     -webkit-box-sizing: $boxmodel;
     -moz-box-sizing: $boxmodel;

--- a/jekyll/repo/_sass/_site-content.scss
+++ b/jekyll/repo/_sass/_site-content.scss
@@ -1,3 +1,7 @@
+body {
+  background-color: $color-bluegrey-50; // same as site-content__people, for infinite sibebar look on wide screens
+}
+
 .site-content--empty {
     padding: 3em 1em;
     text-align: center;
@@ -20,7 +24,6 @@
 
 .site-content__people {
     padding: 1em;
-    background-color: $color-bluegrey-50;
     border-left: 1px solid $color-bluegrey-100;
 
     & > :first-child {
@@ -43,4 +46,8 @@
     .person + h2 {
         margin-top: 2em;
     }
+}
+
+.site-content__tweets {
+  background-color: #fff; // disguise rounded corners on twitter widget
 }

--- a/jekyll/repo/_sass/_site-header.scss
+++ b/jekyll/repo/_sass/_site-header.scss
@@ -58,3 +58,56 @@
         }
     }
 }
+
+@media (max-width: $increment * 1023) {
+  .site-logo {
+    font-size: 1.5em;
+    margin-right: 0.4em;
+  }
+
+  .site-header h2 {
+    display: inline;
+    font-size: 1em;
+    vertical-align: -0.3em; // visually line up with icon beside it
+  }
+}
+
+@media (max-width: $increment * 1023) and (max-height: 649px) {
+  .site-header__about {
+    display: none;
+  }
+}
+
+@media (max-width: $increment * 699) {
+  .site-logo {
+    display: none;
+  }
+
+  .site-header {
+    padding-bottom: 0;
+
+    h2 {
+      vertical-align: 0;
+    }
+
+    h1 {
+      display: inline;
+      margin-left: 0.5em;
+      font-size: 1em;
+
+      a {
+        display: inline;
+        padding: 0;
+        border: 0;
+      }
+    }
+
+    p {
+      display: none;
+    }
+  }
+
+  .site-header__about {
+    display: none;
+  }
+}

--- a/jekyll/repo/_sass/_typography.scss
+++ b/jekyll/repo/_sass/_typography.scss
@@ -103,6 +103,28 @@ input[type="search"] {
     }
 }
 
+.input-append {
+  @include clearfix();
+
+  & > * {
+    float: left;
+  }
+
+  .form-control {
+    width: 70%;
+    border-radius: 0.2em 0 0 0.2em;
+    border-left-width: 1px;
+  }
+
+  .button {
+    width: 30%;
+    padding-left: 0;
+    padding-right: 0;
+    border-radius: 0 0.2em 0.2em 0;
+    border-left-width: 0;
+  }
+}
+
 
 // Replicate the styling from the Twitter widget
 // that will replace this element in a few seconds.


### PR DESCRIPTION
Fixes #15.

The generated jekyll site is now largely usable on all screen sizes. As the screen gets smaller, we drop a few features – notably the "Want to make a site like this?" message and the list of politicians on very small screens.

Here's a few examples.

Huge desktop screen:

![desktop](https://cloud.githubusercontent.com/assets/739624/9662325/e7336fc2-5256-11e5-8fa4-ab4b3186e60f.png)

iPad (landscape)

![ipad-landscape](https://cloud.githubusercontent.com/assets/739624/9662340/fc39e130-5256-11e5-83e4-3670338881d1.png)

iPad (portrait)

![ipad-portrait](https://cloud.githubusercontent.com/assets/739624/9662339/f77f9298-5256-11e5-9d72-969868c57544.png)

Wide-but-short letterbox window (eg: netbooks)

![11-inch-air](https://cloud.githubusercontent.com/assets/739624/9662352/07ac1768-5257-11e5-8ff2-5c98e0a4171a.png)

Phablet

![iphone6plus](https://cloud.githubusercontent.com/assets/739624/9662357/1232eed2-5257-11e5-9bbd-7a9e34b86d18.png)

iPhone 5

![iphone5](https://cloud.githubusercontent.com/assets/739624/9662364/16df89f4-5257-11e5-9e6b-75425cd67700.png)
