### PR TITLE
Group areas by OCD division id if available

### DIFF
--- a/country-au.csv
+++ b/country-au.csv
@@ -1,0 +1,161 @@
+id,name
+ocd-division/country:au,Australia
+ocd-division/country:au/federal_electorate:fraser,Australian Capital Territory and Jarvis Bay Territory - Federal House of Representatives Fraser electorate
+ocd-division/country:au/state:nsw,New South Wales
+ocd-division/country:au/state:nsw/federal_electorate:banks,New South Wales - Federal House of Representatives Banks electorate
+ocd-division/country:au/state:nsw/federal_electorate:barton,New South Wales - Federal House of Representatives Barton electorate
+ocd-division/country:au/state:nsw/federal_electorate:bennelong,New South Wales - Federal House of Representatives Bennelong electorate
+ocd-division/country:au/state:nsw/federal_electorate:berowra,New South Wales - Federal House of Representatives Berowra electorate
+ocd-division/country:au/state:nsw/federal_electorate:blaxland,New South Wales - Federal House of Representatives Blaxland electorate
+ocd-division/country:au/state:nsw/federal_electorate:bradfield,New South Wales - Federal House of Representatives Bradfield electorate
+ocd-division/country:au/state:nsw/federal_electorate:calare,New South Wales - Federal House of Representatives Calare electorate
+ocd-division/country:au/state:nsw/federal_electorate:charlton,New South Wales - Federal House of Representatives Charlton electorate
+ocd-division/country:au/state:nsw/federal_electorate:chifley,New South Wales - Federal House of Representatives Chifley electorate
+ocd-division/country:au/state:nsw/federal_electorate:cook,New South Wales - Federal House of Representatives Cook electorate
+ocd-division/country:au/state:nsw/federal_electorate:cowper,New South Wales - Federal House of Representatives Cowper electorate
+ocd-division/country:au/state:nsw/federal_electorate:cunningham,New South Wales - Federal House of Representatives Cunningham electorate
+ocd-division/country:au/state:nsw/federal_electorate:dobell,New South Wales - Federal House of Representatives Dobell electorate
+ocd-division/country:au/state:nsw/federal_electorate:eden-monaro,New South Wales - Federal House of Representatives Eden-Monaro electorate
+ocd-division/country:au/state:nsw/federal_electorate:farrer,New South Wales - Federal House of Representatives Farrer electorate
+ocd-division/country:au/state:nsw/federal_electorate:fowler,New South Wales - Federal House of Representatives Fowler electorate
+ocd-division/country:au/state:nsw/federal_electorate:gilmore,New South Wales - Federal House of Representatives Gilmore electorate
+ocd-division/country:au/state:nsw/federal_electorate:grayndler,New South Wales - Federal House of Representatives Grayndler electorate
+ocd-division/country:au/state:nsw/federal_electorate:greenway,New South Wales - Federal House of Representatives Greenway electorate
+ocd-division/country:au/state:nsw/federal_electorate:hughes,New South Wales - Federal House of Representatives Hughes electorate
+ocd-division/country:au/state:nsw/federal_electorate:hume,New South Wales - Federal House of Representatives Hume electorate
+ocd-division/country:au/state:nsw/federal_electorate:hunter,New South Wales - Federal House of Representatives Hunter electorate
+ocd-division/country:au/state:nsw/federal_electorate:kingsford_smith,New South Wales - Federal House of Representatives Kingsford Smith electorate
+ocd-division/country:au/state:nsw/federal_electorate:lindsay,New South Wales - Federal House of Representatives Lindsay electorate
+ocd-division/country:au/state:nsw/federal_electorate:lyne,New South Wales - Federal House of Representatives Lyne electorate
+ocd-division/country:au/state:nsw/federal_electorate:macarthur,New South Wales - Federal House of Representatives Macarthur electorate
+ocd-division/country:au/state:nsw/federal_electorate:mackellar,New South Wales - Federal House of Representatives Mackellar electorate
+ocd-division/country:au/state:nsw/federal_electorate:macquarie,New South Wales - Federal House of Representatives Macquarie electorate
+ocd-division/country:au/state:nsw/federal_electorate:mcmahon,New South Wales - Federal House of Representatives McMahon electorate
+ocd-division/country:au/state:nsw/federal_electorate:mitchell,New South Wales - Federal House of Representatives Mitchell electorate
+ocd-division/country:au/state:nsw/federal_electorate:new_england,New South Wales - Federal House of Representatives New England electorate
+ocd-division/country:au/state:nsw/federal_electorate:newcastle,New South Wales - Federal House of Representatives Newcastle electorate
+ocd-division/country:au/state:nsw/federal_electorate:north_sydney,New South Wales - Federal House of Representatives North Sydney electorate
+ocd-division/country:au/state:nsw/federal_electorate:page,New South Wales - Federal House of Representatives Page electorate
+ocd-division/country:au/state:nsw/federal_electorate:parkes,New South Wales - Federal House of Representatives Parkes electorate
+ocd-division/country:au/state:nsw/federal_electorate:parramatta,New South Wales - Federal House of Representatives Parramatta electorate
+ocd-division/country:au/state:nsw/federal_electorate:paterson,New South Wales - Federal House of Representatives Paterson electorate
+ocd-division/country:au/state:nsw/federal_electorate:reid,New South Wales - Federal House of Representatives Reid electorate
+ocd-division/country:au/state:nsw/federal_electorate:richmond,New South Wales - Federal House of Representatives Richmond electorate
+ocd-division/country:au/state:nsw/federal_electorate:riverina,New South Wales - Federal House of Representatives Riverina electorate
+ocd-division/country:au/state:nsw/federal_electorate:robertson,New South Wales - Federal House of Representatives Robertson electorate
+ocd-division/country:au/state:nsw/federal_electorate:shortland,New South Wales - Federal House of Representatives Shortland electorate
+ocd-division/country:au/state:nsw/federal_electorate:sydney,New South Wales - Federal House of Representatives Sydney electorate
+ocd-division/country:au/state:nsw/federal_electorate:throsby,New South Wales - Federal House of Representatives Throsby electorate
+ocd-division/country:au/state:nsw/federal_electorate:warringah,New South Wales - Federal House of Representatives Warringah electorate
+ocd-division/country:au/state:nsw/federal_electorate:watson,New South Wales - Federal House of Representatives Watson electorate
+ocd-division/country:au/state:nsw/federal_electorate:wentworth,New South Wales - Federal House of Representatives Wentworth electorate
+ocd-division/country:au/state:nsw/federal_electorate:werriwa,New South Wales - Federal House of Representatives Werriwa electorate
+ocd-division/country:au/state:qld,Queensland
+ocd-division/country:au/state:qld/federal_electorate:blair,Queensland - Federal House of Representatives Blair electorate
+ocd-division/country:au/state:qld/federal_electorate:bonner,Queensland - Federal House of Representatives Bonner electorate
+ocd-division/country:au/state:qld/federal_electorate:bowman,Queensland - Federal House of Representatives Bowman electorate
+ocd-division/country:au/state:qld/federal_electorate:brisbane,Queensland - Federal House of Representatives Brisbane electorate
+ocd-division/country:au/state:qld/federal_electorate:capricornia,Queensland - Federal House of Representatives Capricornia electorate
+ocd-division/country:au/state:qld/federal_electorate:dawson,Queensland - Federal House of Representatives Dawson electorate
+ocd-division/country:au/state:qld/federal_electorate:dickson,Queensland - Federal House of Representatives Dickson electorate
+ocd-division/country:au/state:qld/federal_electorate:fadden,Queensland - Federal House of Representatives Fadden electorate
+ocd-division/country:au/state:qld/federal_electorate:fairfax,Queensland - Federal House of Representatives Fairfax electorate
+ocd-division/country:au/state:qld/federal_electorate:fisher,Queensland - Federal House of Representatives Fisher electorate
+ocd-division/country:au/state:qld/federal_electorate:flynn,Queensland - Federal House of Representatives Flynn electorate
+ocd-division/country:au/state:qld/federal_electorate:forde,Queensland - Federal House of Representatives Forde electorate
+ocd-division/country:au/state:qld/federal_electorate:griffith,Queensland - Federal House of Representatives Griffith electorate
+ocd-division/country:au/state:qld/federal_electorate:groom,Queensland - Federal House of Representatives Groom electorate
+ocd-division/country:au/state:qld/federal_electorate:herbert,Queensland - Federal House of Representatives Herbert electorate
+ocd-division/country:au/state:qld/federal_electorate:hinkler,Queensland - Federal House of Representatives Hinkler electorate
+ocd-division/country:au/state:qld/federal_electorate:kennedy,Queensland - Federal House of Representatives Kennedy electorate
+ocd-division/country:au/state:qld/federal_electorate:leichhardt,Queensland - Federal House of Representatives Leichhardt electorate
+ocd-division/country:au/state:qld/federal_electorate:lilley,Queensland - Federal House of Representatives Lilley electorate
+ocd-division/country:au/state:qld/federal_electorate:longman,Queensland - Federal House of Representatives Longman electorate
+ocd-division/country:au/state:qld/federal_electorate:maranoa,Queensland - Federal House of Representatives Maranoa electorate
+ocd-division/country:au/state:qld/federal_electorate:mcpherson,Queensland - Federal House of Representatives McPherson electorate
+ocd-division/country:au/state:qld/federal_electorate:moncrieff,Queensland - Federal House of Representatives Moncrieff electorate
+ocd-division/country:au/state:qld/federal_electorate:moreton,Queensland - Federal House of Representatives Moreton electorate
+ocd-division/country:au/state:qld/federal_electorate:oxley,Queensland - Federal House of Representatives Oxley electorate
+ocd-division/country:au/state:qld/federal_electorate:petrie,Queensland - Federal House of Representatives Petrie electorate
+ocd-division/country:au/state:qld/federal_electorate:rankin,Queensland - Federal House of Representatives Rankin electorate
+ocd-division/country:au/state:qld/federal_electorate:ryan,Queensland - Federal House of Representatives Ryan electorate
+ocd-division/country:au/state:qld/federal_electorate:wide_bay,Queensland - Federal House of Representatives Wide Bay electorate
+ocd-division/country:au/state:qld/federal_electorate:wright,Queensland - Federal House of Representatives Wright electorate
+ocd-division/country:au/state:sa,South Australia
+ocd-division/country:au/state:sa/federal_electorate:adelaide,South Australia - Federal House of Representatives Adelaide electorate
+ocd-division/country:au/state:sa/federal_electorate:barker,South Australia - Federal House of Representatives Barker electorate
+ocd-division/country:au/state:sa/federal_electorate:boothby,South Australia - Federal House of Representatives Boothby electorate
+ocd-division/country:au/state:sa/federal_electorate:grey,South Australia - Federal House of Representatives Grey electorate
+ocd-division/country:au/state:sa/federal_electorate:hindmarsh,South Australia - Federal House of Representatives Hindmarsh electorate
+ocd-division/country:au/state:sa/federal_electorate:kingston,South Australia - Federal House of Representatives Kingston electorate
+ocd-division/country:au/state:sa/federal_electorate:makin,South Australia - Federal House of Representatives Makin electorate
+ocd-division/country:au/state:sa/federal_electorate:mayo,South Australia - Federal House of Representatives Mayo electorate
+ocd-division/country:au/state:sa/federal_electorate:port_adelaide,South Australia - Federal House of Representatives Port Adelaide electorate
+ocd-division/country:au/state:sa/federal_electorate:sturt,South Australia - Federal House of Representatives Sturt electorate
+ocd-division/country:au/state:sa/federal_electorate:wakefield,South Australia - Federal House of Representatives Wakefield electorate
+ocd-division/country:au/state:tas,Tasmania
+ocd-division/country:au/state:tas/federal_electorate:bass,Tasmania - Federal House of Representatives Bass electorate
+ocd-division/country:au/state:tas/federal_electorate:braddon,Tasmania - Federal House of Representatives Braddon electorate
+ocd-division/country:au/state:tas/federal_electorate:denison,Tasmania - Federal House of Representatives Denison electorate
+ocd-division/country:au/state:tas/federal_electorate:franklin,Tasmania - Federal House of Representatives Franklin electorate
+ocd-division/country:au/state:tas/federal_electorate:lyons,Tasmania - Federal House of Representatives Lyons electorate
+ocd-division/country:au/state:vic,Victoria
+ocd-division/country:au/state:vic/federal_electorate:aston,Victoria - Federal House of Representatives Aston electorate
+ocd-division/country:au/state:vic/federal_electorate:ballarat,Victoria - Federal House of Representatives Ballarat electorate
+ocd-division/country:au/state:vic/federal_electorate:batman,Victoria - Federal House of Representatives Batman electorate
+ocd-division/country:au/state:vic/federal_electorate:bendigo,Victoria - Federal House of Representatives Bendigo electorate
+ocd-division/country:au/state:vic/federal_electorate:bruce,Victoria - Federal House of Representatives Bruce electorate
+ocd-division/country:au/state:vic/federal_electorate:calwell,Victoria - Federal House of Representatives Calwell electorate
+ocd-division/country:au/state:vic/federal_electorate:casey,Victoria - Federal House of Representatives Casey electorate
+ocd-division/country:au/state:vic/federal_electorate:chisholm,Victoria - Federal House of Representatives Chisholm electorate
+ocd-division/country:au/state:vic/federal_electorate:corangamite,Victoria - Federal House of Representatives Corangamite electorate
+ocd-division/country:au/state:vic/federal_electorate:corio,Victoria - Federal House of Representatives Corio electorate
+ocd-division/country:au/state:vic/federal_electorate:deakin,Victoria - Federal House of Representatives Deakin electorate
+ocd-division/country:au/state:vic/federal_electorate:dunkley,Victoria - Federal House of Representatives Dunkley electorate
+ocd-division/country:au/state:vic/federal_electorate:flinders,Victoria - Federal House of Representatives Flinders electorate
+ocd-division/country:au/state:vic/federal_electorate:gellibrand,Victoria - Federal House of Representatives Gellibrand electorate
+ocd-division/country:au/state:vic/federal_electorate:gippsland,Victoria - Federal House of Representatives Gippsland electorate
+ocd-division/country:au/state:vic/federal_electorate:goldstein,Victoria - Federal House of Representatives Goldstein electorate
+ocd-division/country:au/state:vic/federal_electorate:gorton,Victoria - Federal House of Representatives Gorton electorate
+ocd-division/country:au/state:vic/federal_electorate:higgins,Victoria - Federal House of Representatives Higgins electorate
+ocd-division/country:au/state:vic/federal_electorate:holt,Victoria - Federal House of Representatives Holt electorate
+ocd-division/country:au/state:vic/federal_electorate:hotham,Victoria - Federal House of Representatives Hotham electorate
+ocd-division/country:au/state:vic/federal_electorate:indi,Victoria - Federal House of Representatives Indi electorate
+ocd-division/country:au/state:vic/federal_electorate:isaacs,Victoria - Federal House of Representatives Isaacs electorate
+ocd-division/country:au/state:vic/federal_electorate:jagajaga,Victoria - Federal House of Representatives Jagajaga electorate
+ocd-division/country:au/state:vic/federal_electorate:kooyong,Victoria - Federal House of Representatives Kooyong electorate
+ocd-division/country:au/state:vic/federal_electorate:la_trobe,Victoria - Federal House of Representatives La Trobe electorate
+ocd-division/country:au/state:vic/federal_electorate:lalor,Victoria - Federal House of Representatives Lalor electorate
+ocd-division/country:au/state:vic/federal_electorate:mallee,Victoria - Federal House of Representatives Mallee electorate
+ocd-division/country:au/state:vic/federal_electorate:maribyrnong,Victoria - Federal House of Representatives Maribyrnong electorate
+ocd-division/country:au/state:vic/federal_electorate:mcewen,Victoria - Federal House of Representatives McEwen electorate
+ocd-division/country:au/state:vic/federal_electorate:mcmillan,Victoria - Federal House of Representatives McMillan electorate
+ocd-division/country:au/state:vic/federal_electorate:melbourne,Victoria - Federal House of Representatives Melbourne electorate
+ocd-division/country:au/state:vic/federal_electorate:melbourne_ports,Victoria - Federal House of Representatives Melbourne Ports electorate
+ocd-division/country:au/state:vic/federal_electorate:menzies,Victoria - Federal House of Representatives Menzies electorate
+ocd-division/country:au/state:vic/federal_electorate:murray,Victoria - Federal House of Representatives Murray electorate
+ocd-division/country:au/state:vic/federal_electorate:scullin,Victoria - Federal House of Representatives Scullin electorate
+ocd-division/country:au/state:vic/federal_electorate:wannon,Victoria - Federal House of Representatives Wannon electorate
+ocd-division/country:au/state:vic/federal_electorate:wills,Victoria - Federal House of Representatives Wills electorate
+ocd-division/country:au/state:wa,Western Australia
+ocd-division/country:au/state:wa/federal_electorate:brand,Western Australia - Federal House of Representatives Brand electorate
+ocd-division/country:au/state:wa/federal_electorate:canning,Western Australia - Federal House of Representatives Canning electorate
+ocd-division/country:au/state:wa/federal_electorate:cowan,Western Australia - Federal House of Representatives Cowan electorate
+ocd-division/country:au/state:wa/federal_electorate:curtin,Western Australia - Federal House of Representatives Curtin electorate
+ocd-division/country:au/state:wa/federal_electorate:durack,Western Australia - Federal House of Representatives Durack electorate
+ocd-division/country:au/state:wa/federal_electorate:forrest,Western Australia - Federal House of Representatives Forrest electorate
+ocd-division/country:au/state:wa/federal_electorate:fremantle,Western Australia - Federal House of Representatives Fremantle electorate
+ocd-division/country:au/state:wa/federal_electorate:hasluck,Western Australia - Federal House of Representatives Hasluck electorate
+ocd-division/country:au/state:wa/federal_electorate:moore,Western Australia - Federal House of Representatives Moore electorate
+ocd-division/country:au/state:wa/federal_electorate:o~connor,Western Australia - Federal House of Representatives O'Connor electorate
+ocd-division/country:au/state:wa/federal_electorate:pearce,Western Australia - Federal House of Representatives Pearce electorate
+ocd-division/country:au/state:wa/federal_electorate:perth,Western Australia - Federal House of Representatives Perth electorate
+ocd-division/country:au/state:wa/federal_electorate:stirling,Western Australia - Federal House of Representatives Stirling electorate
+ocd-division/country:au/state:wa/federal_electorate:swan,Western Australia - Federal House of Representatives Swan electorate
+ocd-division/country:au/state:wa/federal_electorate:tangney,Western Australia - Federal House of Representatives Tangney electorate
+ocd-division/country:au/territory:act,Australian Capital Territory
+ocd-division/country:au/territory:act/federal_electorate:canberra,Australian Capital Territory - Federal House of Representatives Canberra electorate
+ocd-division/country:au/territory:jbt,Jervis Bay Territory
+ocd-division/country:au/territory:nt,Northern Territory
+ocd-division/country:au/territory:nt/federal_electorate:lingiari,Northern Territory - Federal House of Representatives Lingiari electorate
+ocd-division/country:au/territory:nt/federal_electorate:solomon,Northern Territory - Federal House of Representatives Solomon electorate

--- a/jekyll/repo/_layouts/area.html
+++ b/jekyll/repo/_layouts/area.html
@@ -20,7 +20,7 @@ layout: default
         {% if politician.screen_name %}
           <div class="person">
             <h3>{{ politician.name }}</h3>
-            <p><a href="{{ politician.screen_name }}">@{{ politician.screen_name | replace: "@", "" | replace: "http://twitter.com/", "" | replace: "https://twitter.com/", "" }}</a></p>
+            <p><a href="https://twitter.com/{{ politician.screen_name }}">@{{ politician.screen_name | replace: "@", "" | replace: "http://twitter.com/", "" | replace: "https://twitter.com/", "" }}</a></p>
           </div>
         {% endif %}
         {% endfor %}

--- a/lib/ocd_division_id.rb
+++ b/lib/ocd_division_id.rb
@@ -3,13 +3,14 @@ class OcdDivisionId
 
   attr_reader :division_id
   attr_reader :types
+  attr_reader :parts
 
   def initialize(division_id)
     @division_id = division_id
     raise InvalidDivisionId unless valid?
-    parts = division_id.split('/')[1..-1]
+    @parts = division_id.split('/')[1..-1]
     @types = {}
-    parts.each do |type_pair|
+    @parts.each do |type_pair|
       type, type_id = type_pair.split(':')
       @types[type.to_sym] = type_id
     end
@@ -30,5 +31,28 @@ class OcdDivisionId
       break if type_name == type
     end
     id
+  end
+end
+
+class OcdDivsionIdSet
+  include Enumerable
+
+  def initialize(*ids)
+    @ids = ids
+  end
+
+  def each
+    @ids.each { |id| yield id }
+  end
+
+  # Need to find the common type which all ids have
+  def common_type
+    known_types = []
+    each { |id| known_types.push(*id.types.keys) }
+    known_types.uniq.reverse.find do |type|
+      groups = group_by { |id| id.id_for(type) }
+      next if groups.keys.any?(&:nil?)
+      groups.values.any? { |members| members.length > 1 }
+    end
   end
 end

--- a/lib/ocd_division_id.rb
+++ b/lib/ocd_division_id.rb
@@ -1,0 +1,34 @@
+class OcdDivisionId
+  class InvalidDivisionId < StandardError; end
+
+  attr_reader :division_id
+  attr_reader :types
+
+  def initialize(division_id)
+    @division_id = division_id
+    raise InvalidDivisionId unless valid?
+    parts = division_id.split('/')[1..-1]
+    @types = {}
+    parts.each do |type_pair|
+      type, type_id = type_pair.split(':')
+      @types[type.to_sym] = type_id
+    end
+  end
+
+  alias :to_s :division_id
+
+  def valid?
+    division_id.respond_to?(:split) &&
+      division_id.split('/').first == 'ocd-division'
+  end
+
+  def id_for(type)
+    return unless types.keys.include?(type)
+    id = 'ocd-division'
+    types.each do |type_name, type_id|
+      id += "/#{[type_name, type_id].join(':')}"
+      break if type_name == type
+    end
+    id
+  end
+end

--- a/lib/ocd_division_id.rb
+++ b/lib/ocd_division_id.rb
@@ -51,7 +51,6 @@ class OcdDivsionIdSet
     each { |id| known_types.push(*id.types.keys) }
     known_types.uniq.reverse.find do |type|
       groups = group_by { |id| id.id_for(type) }
-      next if groups.keys.any?(&:nil?)
       groups.values.any? { |members| members.length > 1 }
     end
   end

--- a/test/ocd_division_id_test.rb
+++ b/test/ocd_division_id_test.rb
@@ -21,3 +21,35 @@ describe OcdDivisionId do
     end
   end
 end
+
+describe OcdDivsionIdSet do
+  it 'picks the common member in the set' do
+    id = OcdDivisionId.new('ocd-division/country:us/state:ky/county:bourbon_county')
+    id2 = OcdDivisionId.new('ocd-division/country:us/state:ky/county:wyandotte_county')
+    set = OcdDivsionIdSet.new(id, id2)
+    assert_equal :state, set.common_type
+
+    id = OcdDivisionId.new('ocd-division/country:us/state:ky/county:bourbon_county')
+    id2 = OcdDivisionId.new('ocd-division/country:us/state:ky/county:bourbon_county')
+    id3 = OcdDivisionId.new('ocd-division/country:us/state:ky/county:adair_county')
+    set = OcdDivsionIdSet.new(id, id2, id3)
+    assert_equal :county, set.common_type
+
+    id = OcdDivisionId.new('ocd-division/country:us/state:ky/county:bourbon_county')
+    id2 = OcdDivisionId.new('ocd-division/country:us/state:ky/county:bourbon_county')
+    id3 = OcdDivisionId.new('ocd-division/country:us/state:ky/county:adair_county')
+    id4 = OcdDivisionId.new('ocd-division/country:us/state:ky/boobar:adair_county')
+    set = OcdDivsionIdSet.new(id, id2, id3, id4)
+    assert_equal :state, set.common_type
+
+    ids = %w(
+      ocd-division/country:ht/departement:sud/arrondissement:port-salut/circonscription:1
+      ocd-division/country:ht/departement:sud/arrondissement:port-salut/circonscription:2
+      ocd-division/country:ht/departement:sud/arrondissement:côteaux/circonscription:1
+      ocd-division/country:ht/departement:sud/arrondissement:côteaux/circonscription:2
+      ocd-division/country:ht/departement:nord-est/arrondissement:fort-liberté/circonscription:1
+    ).map { |id| OcdDivisionId.new(id) }
+    set = OcdDivsionIdSet.new(*ids)
+    assert_equal :arrondissement, set.common_type
+  end
+end

--- a/test/ocd_division_id_test.rb
+++ b/test/ocd_division_id_test.rb
@@ -1,0 +1,23 @@
+require 'test_helper'
+require 'ocd_division_id'
+
+describe OcdDivisionId do
+  describe '#types' do
+    subject { OcdDivisionId.new('ocd-division/country:us/state:ky/county:bourbon_county') }
+    it 'returns the type requested' do
+      assert_equal 'us', subject.types[:country]
+      assert_equal 'ky', subject.types[:state]
+      assert_equal 'bourbon_county', subject.types[:county]
+    end
+  end
+
+  describe '#id_for' do
+    let(:id) { 'ocd-division/country:us/state:ky/county:bourbon_county' }
+    subject { OcdDivisionId.new(id) }
+    it 'returns part of the division id' do
+      assert_equal id, subject.id_for(:county)
+      assert_equal 'ocd-division/country:us/state:ky', subject.id_for(:state)
+      assert_equal 'ocd-division/country:us', subject.id_for(:country)
+    end
+  end
+end


### PR DESCRIPTION
When there are OCD division ids available for an area we use those to group the people into areas.
- [ ] Find a way of mapping partial OCD ids, e.g. `ocd-division/country:ht/departement:sud/arrondissement:port-salut` to a human readable form, e.g. "Port Salut".

Fixes #8 
