### PR TITLE
Rebuild all sites when there is new everypolitician data

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -132,3 +132,7 @@ post '/submissions/:id/moderate' do
   end
   redirect to('/')
 end
+
+post '/event_handler' do
+  Site.each { |site| FetchDataJob.perform_async(site.id) }
+end


### PR DESCRIPTION
This is quite a heavy handed approach at the moment as it rebuilds all the sites when there's new everypolitician-data, but it can be optimised in the future if necessary.

Fixes #14 
