### PR TITLE
Strip whitespace from area names

### DIFF
--- a/app/jobs/fetch_data_job.rb
+++ b/app/jobs/fetch_data_job.rb
@@ -25,10 +25,10 @@ class FetchDataJob
   end
 
   def parse_areas_from_csv(csv)
-    areas = csv.map { |r| r['area'] }.compact.uniq
+    areas = csv.map { |r| r['area'].strip }.compact.uniq
     areas = areas.map { |a| { name: a } }
     csv.each do |row|
-      area = areas.find { |a| a[:name] == row['area'] }
+      area = areas.find { |a| a[:name] == row['area'].strip }
       area[:politicians] ||= []
       area[:politicians] << {
         id: row['id'],


### PR DESCRIPTION
This is a simple workaround to remove duplicate areas where they've got
the same name but some have trailing or leading whitespace and others
don't.

Fixes #30 
