### PR TITLE
Automatically scroll area list so selected item is in the middle

### DIFF
--- a/jekyll/repo/_layouts/area.html
+++ b/jekyll/repo/_layouts/area.html
@@ -50,3 +50,4 @@ layout: default
         {% endfor %}
     </div>
 </div>
+<script src="{{ '/js/main.js' | prepend: site.baseurl }}"></script>

--- a/jekyll/repo/js/main.js
+++ b/jekyll/repo/js/main.js
@@ -1,0 +1,7 @@
+// If an area is selected in the sidebar, adjust the sidebar's
+// scroll offset so that the selected area appears right in the middle.
+var selectedElement = document.querySelector('.area-list .selected');
+if (selectedElement) {
+  var parentElement = selectedElement.parentNode;
+  parentElement.scrollTop = selectedElement.offsetTop - (parentElement.clientHeight / 2) + (selectedElement.clientHeight / 2);
+}


### PR DESCRIPTION
Fixes #36.

Would be nice to have a smoothly animated scroll, but right now it’s all done without jQuery, so seems a shame to add it just for that.

![banner](https://cloud.githubusercontent.com/assets/739624/10279631/26e5879c-6b5f-11e5-9ed9-043335f42da6.gif)
