### PR TITLE
Clear message when area has no tweets

### DIFF
--- a/jekyll/repo/_layouts/area.html
+++ b/jekyll/repo/_layouts/area.html
@@ -1,37 +1,72 @@
 ---
 layout: default
 ---
-<div class="site-content">
-  {% if page.list_slug %}
-    <div class="site-content__tweets">
-        <a class="twitter-timeline"
-          data-dnt="true"
-          data-chrome="noborders"
-          href="https://twitter.com/{{ site.list_owner_screen_name }}/lists/{{ page.list_slug }}"
-          data-widget-id="598799140756320256"
-          data-list-owner-screen-name="{{ site.list_owner_screen_name }}"
-          data-list-slug="{{ page.list_slug }}">
-          <span class="twitter-timeline__name">{{ page.name }}</span>
-          <span class="twitter-timeline__loading">Loading tweets…</span>
-        </a>
-    </div>
+
+{% assign tweeting_politicians = 0 %}
+{% assign other_politicians = 0 %}
+
+{% for politician in page.politicians %}
+  {% if politician.screen_name %}
+    {% capture tweeting_politicians %}{{ tweeting_politicians | plus: 1 }}{% endcapture %}
   {% else %}
-    <p>No Twitter list exists for this area.</p>
+    {% capture other_politicians %}{{ other_politicians | plus: 1 }}{% endcapture %}
   {% endif %}
+{% endfor %}
+
+{% assign tweeting_politicians = tweeting_politicians | plus: 0 %}
+{% assign other_politicians = other_politicians | plus: 0 %}
+
+<div class="site-content">
+    <div class="site-content__tweets">
+      {% if tweeting_politicians > 0 and page.list_slug %}
+        <a class="twitter-timeline"
+            data-dnt="true"
+            data-chrome="noborders"
+            href="https://twitter.com/{{ site.list_owner_screen_name }}/lists/{{ page.list_slug }}"
+            data-widget-id="598799140756320256"
+            data-list-owner-screen-name="{{ site.list_owner_screen_name }}"
+            data-list-slug="{{ page.list_slug }}">
+            <span class="twitter-timeline__name">{{ page.name }}</span>
+            <span class="twitter-timeline__loading">Loading tweets…</span>
+        </a>
+      {% elsif tweeting_politicians == 0 %}
+        <div class="timeline-header">
+            <span class="twitter-timeline__name">{{ page.name }}</span>
+            <span class="twitter-timeline__loading">No politicians tweeting here?</span>
+        </div>
+        <div class="empty-timeline-message">
+            <p>We don’t know about any politicians who tweet in {{ page.name }}.</p>
+            <p>Perhaps you can help us find some?</p>
+        </div>
+      {% else %}
+        <div class="timeline-header">
+            <span class="twitter-timeline__name">{{ page.name }}</span>
+            <span class="twitter-timeline__loading">No politicians tweeting here?</span>
+        </div>
+        <div class="empty-timeline-message">
+            <p>Hmm… something went wrong. There’s no Twitter list for this area.</p>
+        </div>
+      {% endif %}
+    </div>
     <div class="site-content__people">
+
+      {% if tweeting_politicians > 0 %}
         <h2>Politicians tweeting here</h2>
+
         {% for politician in page.politicians %}
-        {% if politician.screen_name %}
+          {% if politician.screen_name %}
           <div class="person">
             <h3>{{ politician.name }}</h3>
             <p><a href="https://twitter.com/{{ politician.screen_name }}">@{{ politician.screen_name | replace: "@", "" | replace: "http://twitter.com/", "" | replace: "https://twitter.com/", "" }}</a></p>
           </div>
-        {% endif %}
+          {% endif %}
         {% endfor %}
+      {% endif %}
 
+      {% if other_politicians > 0 %}
         <h2>Other politicians here</h2>
 
-        {% for politician in page.politicians %}
+      {% for politician in page.politicians %}
         {% unless politician.screen_name %}
         <form class="person" action="{{ site.submission_url }}" method="post">
             <input type="hidden" name="submission[site_id]" value="{{ site.site_id }}">
@@ -44,9 +79,12 @@ layout: default
                     <input id="id_username_{{ politician.id }}" class="form-control" type="text" name="submission[twitter]" placeholder="@username">
                     <button type="submit" class="button">Add</button>
                 </span>
-            </p>
+              </p>
         </form>
         {% endunless %}
-        {% endfor %}
+      {% endfor %}
+
+      {% endif %}
+
     </div>
 </div>

--- a/jekyll/repo/_sass/_layout.scss
+++ b/jekyll/repo/_sass/_layout.scss
@@ -74,7 +74,7 @@ html, body {
     display: block !important;
 }
 
-iframe.twitter-timeline[data-widget-id] + a.twitter-timeline {
+iframe.twitter-timeline[data-widget-id] + .twitter-timeline {
   // There's a split second where the iframe and the placeholder link
   // both exist in the DOM at the same time, while the twitter widget is
   // in the process of loading. This is the gap between the iframe being

--- a/jekyll/repo/_sass/_site-content.scss
+++ b/jekyll/repo/_sass/_site-content.scss
@@ -17,9 +17,18 @@ body {
 }
 
 .site-content {
-    a.twitter-timeline {
+    .twitter-timeline,
+    .timeline-header {
         padding: 1em;
     }
+}
+
+.empty-timeline-message {
+    margin: 0 1em 1em 1em;
+    padding: 1em;
+    text-align: center;
+    background-color: $color-yellow-100;
+    border-radius: 0.3em;
 }
 
 .site-content__people {

--- a/jekyll/repo/_sass/_typography.scss
+++ b/jekyll/repo/_sass/_typography.scss
@@ -128,12 +128,15 @@ input[type="search"] {
 
 // Replicate the styling from the Twitter widget
 // that will replace this element in a few seconds.
-a.twitter-timeline {
+.twitter-timeline,
+.timeline-header {
   text-decoration: none;
   color: inherit;
   font: 12px/16px 'Helvetica Neue', Roboto, 'Segoe UI', Calibri, sans-serif;
   padding: 12px;
+}
 
+a.twitter-timeline {
   &:hover, &:focus {
     .twitter-timeline__loading {
       text-decoration: underline;

--- a/jekyll/repo/_sass/_variables.scss
+++ b/jekyll/repo/_sass/_variables.scss
@@ -31,3 +31,6 @@ $color-blue-600: #1E88E5;
 $color-blue-700: #1976D2;
 $color-blue-800: #1565C0;
 $color-blue-900: #0D47A1;
+
+$color-yellow-50: #FFFDE7;
+$color-yellow-100: #FFF9C4;


### PR DESCRIPTION
![screen shot 2015-10-05 at 15 44 14](https://cloud.githubusercontent.com/assets/739624/10283552/f60bfc1e-6b77-11e5-9e2b-4707098c8ea7.png)

Fixes #23.

The huge chunk of Liquid boilerplate at the top of area.html is the best way of incrementing two variables in Liquid, without losing the ability to go `var == 0` for the initial case (which using the built-in `{% increment %}` tag doesn't get you).

Also fixes #25 by hiding the person section headings until there’s actually a list of people below them.
