### PR TITLE
Make it easier to scroll the people list

### DIFF
--- a/jekyll/repo/_sass/_layout.scss
+++ b/jekyll/repo/_sass/_layout.scss
@@ -48,7 +48,6 @@ html, body {
     height: 100%;
     left: $desktop-header-width + $desktop-nav-width;
     overflow: auto;
-    max-width: $desktop-timeline-width + $desktop-people-width;
 }
 
 .site-content__tweets {
@@ -82,6 +81,26 @@ iframe.twitter-timeline[data-widget-id] + a.twitter-timeline {
   // being hidden. So, we hide the placeholder with CSS here, to avoid
   // a scrollbar being shown (because of two 100% height elements).
   display: none !important;
+}
+
+@media (min-width: $increment * 1024) {
+  // On browsers that support CSS calc() we stretch the people list
+  // to fill the space to the right of the twitter timeline.
+
+  .site-content__tweets {
+    // We use calc here as a no-op, just so that the max-width
+    // is ignored by any browsers that don't support calc().
+    max-width: calc(0em + #{$desktop-timeline-width});
+  }
+
+  .site-content__people {
+    // Width is whatever's left of the parent width after the
+    // timeline has been put in.
+    width: calc(100% - #{$desktop-timeline-width});
+    // Another calc() no-op, to stop min-width being applied
+    // by browsers that don't support the calc() width above.
+    min-width: calc(0em + #{$desktop-people-width});
+  }
 }
 
 @media (max-width: $increment * 1023) {


### PR DESCRIPTION
In browsers that support CSS calc(), the people list now fills the entire space to the right of the timeline, which means you can more easily scroll it. Fixes #40.

![screen shot 2015-10-06 at 14 10 10](https://cloud.githubusercontent.com/assets/739624/10309480/ba67d2ba-6c34-11e5-8e66-77cb28a6b09e.png)

In browsers that don’t support calc(), the people list will be 15em wide, and pinned to the right edge of the window. The timeline will be 30em, and there’ll be a white gap between them.
